### PR TITLE
Update react-native to 0.61.5, react 16.12.0, reagent 0.9.1, shadow-cljs 2.8.83

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ $ react-native run-android
 ;; production build
 $ shadow-cljs release app
 
-;; no clue what to do for react-native
+;; Create Android release
+$ cd react-native/android
+$ ./gradlew assembleRelease
+;; APK should appear at android/app/build/outputs/apk/release
+;; installs in Android as "Hello App Display Name"
 ```
 
 ## Notes

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "AwesomeProject",
   "version": "0.0.1",
   "private": true,
-  "dependencies": {
-    "react": "16.9.0",
-    "react-dom": "16.9.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "shadow-cljs": "^2.8.83"
   }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "AwesomeProject",
   "version": "0.0.1",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "react": "16.9.0",
+    "react-dom": "16.9.0"
+  },
   "devDependencies": {
-    "shadow-cljs": "^2.8.53"
+    "shadow-cljs": "^2.8.83"
   }
 }

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -7,17 +7,17 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "16.8.6",
-    "react-native": "0.60.5"
+    "react": "16.12.0",
+    "react-native": "0.61.5"
   },
   "devDependencies": {
-    "@babel/core": "^7.5.0",
-    "@babel/runtime": "^7.5.0",
-    "@react-native-community/eslint-config": "^0.0.3",
-    "babel-jest": "^24.1.0",
-    "jest": "^24.1.0",
-    "metro-react-native-babel-preset": "0.54.1",
-    "react-test-renderer": "16.8.6"
+    "@babel/core": "^7.8.4",
+    "@babel/runtime": "^7.8.4",
+    "@react-native-community/eslint-config": "^0.0.7",
+    "babel-jest": "^25.1.0",
+    "jest": "^25.1.0",
+    "metro-react-native-babel-preset": "0.58.0",
+    "react-test-renderer": "16.12.0"
   },
   "jest": {
     "preset": "react-native"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -5,7 +5,7 @@
   "src/test"]
 
  :dependencies
- [[reagent "0.8.1"]]
+ [[reagent "0.9.1"]]
 
  :builds
  {:app


### PR DESCRIPTION
Also includes simple instructions on assembling an Android production app release.

React native dependencies were updated via instructions at https://stackoverflow.com/a/16074029/4598041 -- namely `ncu -u`