### PR TITLE
Adds :infer-externs :auto to shadow-cljs.edn

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -12,4 +12,5 @@
   {:target :react-native
    :init-fn test.app/init
    :output-dir "react-native/app"
+   :compiler-options {:infer-externs :auto}
    :js-options {:js-package-dirs ["react-native/node_modules"]}}}}


### PR DESCRIPTION
Non-trivial builds tend to break in release mode without this. (Found out the hard way 🙂 )

Note that trivial builds -- like the default one in this repo -- _do work_ in release mode without this option, but since it's likely that anyone forking this repo will eventually encounter this issue I recommend including it in this example.