### PR TITLE
fix android building failure

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "create-react-class": "^15.7.0",
     "react": "17.0.1",
-    "react-native": "0.64.2"
+    "react-native": "0.64.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/react-native/yarn.lock
+++ b/react-native/yarn.lock
@@ -5100,10 +5100,10 @@ react-native-codegen@^0.0.6:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
-react-native@0.64.2:
-  version "0.64.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.2.tgz#233b6ed84ac4749c8bc2a2d6cf63577a1c437d18"
-  integrity sha512-Ty/fFHld9DcYsFZujXYdeVjEhvSeQcwuTGXezyoOkxfiGEGrpL/uwUZvMzwShnU4zbbTKDu2PAm/uwuOittRGA==
+react-native@0.64.4:
+  version "0.64.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.4.tgz#f9870f6951378421881cc66f6b5a6451bef7254d"
+  integrity sha512-nxYt/NrTmGyW6+tOd+Hqp4O8uJ2LLZkN7ispMPDprAq7bwvLkF/GXmDQCZHAEyqXuhIztTtMX41KqFQ6UMCUJQ==
   dependencies:
     "@jest/create-cache-key-function" "^26.5.0"
     "@react-native-community/cli" "^5.0.1-alpha.1"


### PR DESCRIPTION
refer to this issue
https://github.com/facebook/react-native/issues/35210

Android build failure with the following output. It was fixed after upgrade to react-native 0.64.4

`
PS C:\code\clj\reagent-react-native\react-native> npm run android

> awesomeproject@0.0.1 android
> react-native run-android

info Running jetifier to migrate libraries to AndroidX. You can disable it using "--no-jetifier" flag.
Jetifier found 896 file(s) to forward-jetify. Using 8 workers...
info JS server already running.
info Launching emulator...
info Successfully launched emulator.
info Installing the app...
Starting a Gradle Daemon (subsequent builds will be faster)
> Task :app:checkDebugAarMetadata FAILED
4 actionable tasks: 4 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform react-native-0.71.0-rc.0-debug.aar (com.facebook.react:react-native:0.71.0-rc.0) to match attributes {artifactType=android-aar-metadata, com.android.build.api.attributes.BuildTypeAttr=debug, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for JetifyTransform: C:\Users\jeff\.gradle\caches\modules-2\files-2.1\com.facebook.react\react-native\0.71.0-rc.0\7a7f5a0af6ebd8eb94f7e5f7495e9d9684b4f543\react-native-0.71.0-rc.0-debug.aar.
         > Java heap space

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 31s

error Failed to install the app. Make sure you have the Android development environment set up: https://reactnative.dev/docs/environment-setup.
Error: Command failed: gradlew.bat app:installDebug -PreactNativeDevServerPort=8081

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform react-native-0.71.0-rc.0-debug.aar (com.facebook.react:react-native:0.71.0-rc.0) to match attributes {artifactType=android-aar-metadata, com.android.build.api.attributes.BuildTypeAttr=debug, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for JetifyTransform: C:\Users\jeff\.gradle\caches\modules-2\files-2.1\com.facebook.react\react-native\0.71.0-rc.0\7a7f5a0af6ebd8eb94f7e5f7495e9d9684b4f543\react-native-0.71.0-rc.0-debug.aar.
         > Java heap space

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 31s

    at makeError (C:\code\clj\reagent-react-native\react-native\node_modules\execa\index.js:174:9)
    at C:\code\clj\reagent-react-native\react-native\node_modules\execa\index.js:278:16
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async runOnAllDevices (C:\code\clj\reagent-react-native\react-native\node_modules\@react-native-community\cli-platform-android\build\commands\runAndroid\runOnAllDevices.js:94:5)
    at async Command.handleAction (C:\code\clj\reagent-react-native\react-native\node_modules\@react-native-community\cli\build\index.js:186:9)
info Run CLI with --verbose flag for more details.
PS C:\code\clj\reagent-react-native\react-native>
`